### PR TITLE
Implement core neural network layers (Dense, Conv2D, RNN)

### DIFF
--- a/activation_functions/activation_functions.go
+++ b/activation_functions/activation_functions.go
@@ -64,11 +64,9 @@ func Sigmoid(t *tensor.Tensor) *tensor.Tensor {
 
 // tanh activation function; f(x) = (e^(x) - e^(-x))/(e^(x) + e^(-x))
 func Tanh(t *tensor.Tensor) *tensor.Tensor {
-
 	result := make([]float64, len(t.Data))
 	for i := range t.Data {
-		result[i] = (math.Exp(t.Data[i]-math.Exp(-t.Data[i])) / (math.Exp(t.Data[i]) + math.Exp(-t.Data[i])))
+		result[i] = math.Tanh(t.Data[i])
 	}
 	return &tensor.Tensor{Data: result, Shape: t.Shape}
-
 }

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the gotorch library
 package main
 
 import (
@@ -7,21 +8,26 @@ import (
 )
 
 func main() {
+	// Create input tensor with shape [2, 2] representing 2 samples with 2 features each
 	inputs := tensor.NewTensor([][]float64{{1.0, 2.0}, {3.0, 4.0}})
+
+	// Create target tensor with shape [2, 1] representing desired outputs
 	targets := tensor.NewTensor([][]float64{{5.0}, {11.0}})
 
+	// Initialize a linear model with weights [1.0, 2.0] and bias [0.5]
 	model := &model.Linear{
 		Weights: []float64{1.0, 2.0},
 		Biases:  []float64{0.5},
 	}
 
-	epochs := 100
-	learningRate := 0.1
+	// Training hyperparameters
+	epochs := 100       // Number of complete passes through the training data
+	learningRate := 0.1 // Step size for gradient descent updates
 
-	// Train the model
+	// Train the model using gradient descent
 	model.Train(model, inputs, targets, epochs, learningRate)
 
-	// Sample the trained model
+	// Test the trained model on new data
 	newInput := tensor.NewTensor([][]float64{{5.0, 6.0}})
 	prediction := model.Sample(model, newInput)
 

--- a/nn/conv2d.go
+++ b/nn/conv2d.go
@@ -1,3 +1,4 @@
+// Package nn implements neural network layers and components
 package nn
 
 import (
@@ -6,29 +7,39 @@ import (
 	"math/rand"
 )
 
+// Conv2D implements a 2D convolutional layer.
+// Applies sliding filters over a 4D input tensor [batch_size, channels, height, width]
+// to produce feature maps through local connectivity patterns.
 type Conv2D struct {
-	InChannels  int
-	OutChannels int
-	KernelSize  int
-	Stride      int
-	Padding     int
+	InChannels  int // Number of input channels
+	OutChannels int // Number of output channels (filters)
+	KernelSize  int // Size of the convolving kernel (assumed square)
+	Stride      int // Step size of the convolution
+	Padding     int // Zero-padding size around the input
 
-	Filters *tensor.Tensor
-	Biases  *tensor.Tensor
-	Input   *tensor.Tensor
+	Filters *tensor.Tensor // Filter weights of shape [out_channels, in_channels, kernel_size, kernel_size]
+	Biases  *tensor.Tensor // Bias terms of shape [out_channels]
+	Input   *tensor.Tensor // Stores input for backpropagation
 
-	FilterGrads *tensor.Tensor
-	BiasGrads   *tensor.Tensor
+	// Gradients for optimization
+	FilterGrads *tensor.Tensor // Accumulated gradients for filters
+	BiasGrads   *tensor.Tensor // Accumulated gradients for biases
 }
 
+// NewConv2D creates a new 2D convolutional layer with specified dimensions.
+// Filters are initialized using He/Kaiming initialization, which is particularly
+// suitable for layers using ReLU activation.
 func NewConv2D(inChannels, outChannels, kernelSize int, stride, padding int) *Conv2D {
+	// He/Kaiming initialization scale
 	scale := math.Sqrt(2.0 / float64(inChannels*kernelSize*kernelSize))
 
+	// Initialize filters with scaled normal distribution
 	filters := make([]float64, outChannels*inChannels*kernelSize*kernelSize)
 	for i := range filters {
 		filters[i] = rand.NormFloat64() * scale
 	}
 
+	// Initialize biases to zero
 	biases := make([]float64, outChannels)
 
 	return &Conv2D{
@@ -42,13 +53,19 @@ func NewConv2D(inChannels, outChannels, kernelSize int, stride, padding int) *Co
 	}
 }
 
+// Forward performs the forward pass of the convolution operation.
+// For each filter:
+// 1. Applies filter across input volume in a sliding window fashion
+// 2. Computes dot product between filter and input window at each position
+// 3. Adds bias term to create output feature map
 func (c *Conv2D) Forward(input *tensor.Tensor) *tensor.Tensor {
-	c.Input = input
+	c.Input = input // Save for backprop
 
 	batchSize := input.Shape[0]
 	inputHeight := input.Shape[2]
 	inputWidth := input.Shape[3]
 
+	// Calculate output dimensions with padding and stride
 	outputHeight := (inputHeight+2*c.Padding-c.KernelSize)/c.Stride + 1
 	outputWidth := (inputWidth+2*c.Padding-c.KernelSize)/c.Stride + 1
 
@@ -58,12 +75,17 @@ func (c *Conv2D) Forward(input *tensor.Tensor) *tensor.Tensor {
 		batchSize, c.OutChannels, outputHeight, outputWidth,
 	)
 
-	// Implementation of convolution operation
-	// TODO: Implement im2col transformation and matrix multiplication
-	// For now this is just a placeholder that copies input to output
+	// TODO: Implement convolution operation using im2col and matrix multiplication
+	// Current implementation is a placeholder that copies input to output
 	copy(output.Data, input.Data[:len(output.Data)])
 
 	return output
 }
 
-// ... Backward and UpdateParams methods
+// TODO: Add Backward and UpdateParams methods
+// Backward should compute:
+// - Gradient with respect to input
+// - Gradient with respect to filters
+// - Gradient with respect to biases
+//
+// UpdateParams should update filters and biases using computed gradients

--- a/nn/conv2d.go
+++ b/nn/conv2d.go
@@ -1,0 +1,69 @@
+package nn
+
+import (
+	"gotorch/tensor"
+	"math"
+	"math/rand"
+)
+
+type Conv2D struct {
+	InChannels  int
+	OutChannels int
+	KernelSize  int
+	Stride      int
+	Padding     int
+
+	Filters *tensor.Tensor
+	Biases  *tensor.Tensor
+	Input   *tensor.Tensor
+
+	FilterGrads *tensor.Tensor
+	BiasGrads   *tensor.Tensor
+}
+
+func NewConv2D(inChannels, outChannels, kernelSize int, stride, padding int) *Conv2D {
+	scale := math.Sqrt(2.0 / float64(inChannels*kernelSize*kernelSize))
+
+	filters := make([]float64, outChannels*inChannels*kernelSize*kernelSize)
+	for i := range filters {
+		filters[i] = rand.NormFloat64() * scale
+	}
+
+	biases := make([]float64, outChannels)
+
+	return &Conv2D{
+		InChannels:  inChannels,
+		OutChannels: outChannels,
+		KernelSize:  kernelSize,
+		Stride:      stride,
+		Padding:     padding,
+		Filters:     tensor.NewTensor(filters, outChannels, inChannels, kernelSize, kernelSize),
+		Biases:      tensor.NewTensor(biases, outChannels),
+	}
+}
+
+func (c *Conv2D) Forward(input *tensor.Tensor) *tensor.Tensor {
+	c.Input = input
+
+	batchSize := input.Shape[0]
+	inputHeight := input.Shape[2]
+	inputWidth := input.Shape[3]
+
+	outputHeight := (inputHeight+2*c.Padding-c.KernelSize)/c.Stride + 1
+	outputWidth := (inputWidth+2*c.Padding-c.KernelSize)/c.Stride + 1
+
+	// Create output tensor
+	output := tensor.NewTensor(
+		make([]float64, batchSize*c.OutChannels*outputHeight*outputWidth),
+		batchSize, c.OutChannels, outputHeight, outputWidth,
+	)
+
+	// Implementation of convolution operation
+	// TODO: Implement im2col transformation and matrix multiplication
+	// For now this is just a placeholder that copies input to output
+	copy(output.Data, input.Data[:len(output.Data)])
+
+	return output
+}
+
+// ... Backward and UpdateParams methods

--- a/nn/conv2d_test.go
+++ b/nn/conv2d_test.go
@@ -1,0 +1,74 @@
+package nn
+
+import (
+	"gotorch/tensor"
+	"reflect"
+	"testing"
+)
+
+func Test_NewConv2D(t *testing.T) {
+	inChannels := 3
+	outChannels := 16
+	kernelSize := 3
+	stride := 1
+	padding := 1
+
+	conv := NewConv2D(inChannels, outChannels, kernelSize, stride, padding)
+
+	// Check dimensions
+	expectedFilterShape := []int{outChannels, inChannels, kernelSize, kernelSize}
+	if !reflect.DeepEqual(conv.Filters.Shape, expectedFilterShape) {
+		t.Errorf("Incorrect filter shape: got %v, want %v", conv.Filters.Shape, expectedFilterShape)
+	}
+
+	expectedBiasShape := []int{outChannels}
+	if !reflect.DeepEqual(conv.Biases.Shape, expectedBiasShape) {
+		t.Errorf("Incorrect bias shape: got %v, want %v", conv.Biases.Shape, expectedBiasShape)
+	}
+}
+
+func Test_Conv2DForward(t *testing.T) {
+	conv := NewConv2D(1, 1, 3, 1, 1)
+
+	// Simple 4x4 input with batch size 1 and 1 channel
+	input := tensor.NewTensor([]float64{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+		13, 14, 15, 16,
+	}, 1, 1, 4, 4)
+
+	output := conv.Forward(input)
+
+	// Check output dimensions
+	expectedShape := []int{1, 1, 4, 4} // Same padding
+	if !reflect.DeepEqual(output.Shape, expectedShape) {
+		t.Errorf("Incorrect output shape: got %v, want %v", output.Shape, expectedShape)
+	}
+
+	// Verify output size matches expected dimensions
+	expectedSize := 1 * 1 * 4 * 4 // batch * channels * height * width
+	if len(output.Data) != expectedSize {
+		t.Errorf("Incorrect output size: got %d, want %d", len(output.Data), expectedSize)
+	}
+}
+
+func Test_Conv2DForwardMultiChannel(t *testing.T) {
+	conv := NewConv2D(3, 2, 3, 1, 1)
+
+	// 4x4 input with batch size 2 and 3 channels
+	input := tensor.NewTensor(make([]float64, 2*3*4*4), 2, 3, 4, 4)
+
+	output := conv.Forward(input)
+
+	// Check output dimensions
+	expectedShape := []int{2, 2, 4, 4} // batch, out_channels, height, width
+	if !reflect.DeepEqual(output.Shape, expectedShape) {
+		t.Errorf("Incorrect output shape: got %v, want %v", output.Shape, expectedShape)
+	}
+
+	expectedSize := 2 * 2 * 4 * 4 // batch * out_channels * height * width
+	if len(output.Data) != expectedSize {
+		t.Errorf("Incorrect output size: got %d, want %d", len(output.Data), expectedSize)
+	}
+}

--- a/nn/dense.go
+++ b/nn/dense.go
@@ -1,0 +1,90 @@
+package nn
+
+import (
+	"gotorch/tensor"
+	"math"
+	"math/rand"
+)
+
+type Dense struct {
+	InputDim  int
+	OutputDim int
+	Weights   *tensor.Tensor
+	Biases    *tensor.Tensor
+	Input     *tensor.Tensor // Store for backprop
+
+	// Gradients
+	WeightGrads *tensor.Tensor
+	BiasGrads   *tensor.Tensor
+}
+
+func NewDense(inputDim, outputDim int) *Dense {
+	// Xavier/Glorot initialization
+	scale := math.Sqrt(2.0 / float64(inputDim+outputDim))
+
+	weights := make([]float64, inputDim*outputDim)
+	for i := range weights {
+		weights[i] = rand.NormFloat64() * scale
+	}
+
+	biases := make([]float64, outputDim)
+
+	return &Dense{
+		InputDim:    inputDim,
+		OutputDim:   outputDim,
+		Weights:     tensor.NewTensor(weights, inputDim, outputDim),
+		Biases:      tensor.NewTensor(biases, outputDim),
+		WeightGrads: tensor.NewTensor(make([]float64, inputDim*outputDim), inputDim, outputDim),
+		BiasGrads:   tensor.NewTensor(make([]float64, outputDim), outputDim),
+	}
+}
+
+func (d *Dense) Forward(input *tensor.Tensor) *tensor.Tensor {
+	d.Input = input // Save for backprop
+
+	// Compute output = input * weights + biases
+	output, err := tensor.Dot(input, d.Weights)
+	if err != nil {
+		panic(err)
+	}
+
+	// Broadcast biases to match output shape
+	batchSize := input.Shape[0]
+	broadcastBiases := tensor.NewTensor(make([]float64, batchSize*d.OutputDim), batchSize, d.OutputDim)
+	for i := 0; i < batchSize; i++ {
+		copy(broadcastBiases.Data[i*d.OutputDim:(i+1)*d.OutputDim], d.Biases.Data)
+	}
+
+	result, err := tensor.Add(output, broadcastBiases)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+func (d *Dense) Backward(gradOutput *tensor.Tensor) *tensor.Tensor {
+	// Compute gradients
+	// dW = input^T * gradOutput
+	inputT := tensor.Transpose(d.Input)
+	d.WeightGrads, _ = tensor.Dot(inputT, gradOutput)
+
+	// dB = sum(gradOutput, axis=0)
+	d.BiasGrads = tensor.SumAxis(gradOutput, 0)
+
+	// Compute gradient with respect to input
+	// dX = gradOutput * W^T
+	weightsT := tensor.Transpose(d.Weights)
+	inputGrad, _ := tensor.Dot(gradOutput, weightsT)
+
+	return inputGrad
+}
+
+func (d *Dense) UpdateParams(learningRate float64) {
+	// Update weights and biases using gradients
+	weightUpdate, _ := tensor.Multiply(d.WeightGrads, tensor.NewTensor(learningRate))
+	d.Weights, _ = tensor.Subtract(d.Weights, weightUpdate)
+
+	biasUpdate, _ := tensor.Multiply(d.BiasGrads, tensor.NewTensor(learningRate))
+	d.Biases, _ = tensor.Subtract(d.Biases, biasUpdate)
+}

--- a/nn/dense_test.go
+++ b/nn/dense_test.go
@@ -1,0 +1,105 @@
+package nn
+
+import (
+	"gotorch/tensor"
+	"reflect"
+	"testing"
+)
+
+func Test_NewDense(t *testing.T) {
+	inputDim := 4
+	outputDim := 3
+
+	dense := NewDense(inputDim, outputDim)
+
+	// Check dimensions
+	expectedWeightShape := []int{inputDim, outputDim}
+	if !reflect.DeepEqual(dense.Weights.Shape, expectedWeightShape) {
+		t.Errorf("Incorrect weight shape: got %v, want %v", dense.Weights.Shape, expectedWeightShape)
+	}
+
+	expectedBiasShape := []int{outputDim}
+	if !reflect.DeepEqual(dense.Biases.Shape, expectedBiasShape) {
+		t.Errorf("Incorrect bias shape: got %v, want %v", dense.Biases.Shape, expectedBiasShape)
+	}
+}
+
+func Test_DenseForward(t *testing.T) {
+	dense := NewDense(2, 3)
+
+	// Set weights and biases for predictable output
+	weights := tensor.NewTensor([][]float64{
+		{1, 2, 3},
+		{4, 5, 6},
+	})
+	biases := tensor.NewTensor([]float64{0.1, 0.2, 0.3})
+
+	dense.Weights = weights
+	dense.Biases = biases
+	dense.WeightGrads = tensor.NewTensor(make([]float64, 2*3), 2, 3)
+	dense.BiasGrads = tensor.NewTensor(make([]float64, 3), 3)
+
+	// Input: batch size of 2, each with 2 features
+	input := tensor.NewTensor([][]float64{
+		{1, 2},
+		{3, 4},
+	})
+
+	output := dense.Forward(input)
+
+	expectedShape := []int{2, 3}
+	if !reflect.DeepEqual(output.Shape, expectedShape) {
+		t.Errorf("Incorrect output shape: got %v, want %v", output.Shape, expectedShape)
+	}
+
+	// Expected output calculation:
+	// First sample: [1*1 + 2*4 + 0.1, 1*2 + 2*5 + 0.2, 1*3 + 2*6 + 0.3]
+	// Second sample: [3*1 + 4*4 + 0.1, 3*2 + 4*5 + 0.2, 3*3 + 4*6 + 0.3]
+	expectedOutput := []float64{
+		9.1, 12.2, 15.3, // First sample
+		19.1, 26.2, 33.3, // Second sample
+	}
+
+	for i, val := range output.Data {
+		if !floatEquals(val, expectedOutput[i], 1e-6) {
+			t.Errorf("Incorrect output at index %d: got %v, want %v", i, val, expectedOutput[i])
+		}
+	}
+}
+
+func Test_DenseBackward(t *testing.T) {
+	dense := NewDense(2, 3)
+
+	// Set weights for predictable output
+	dense.Weights = tensor.NewTensor([][]float64{
+		{1, 2, 3},
+		{4, 5, 6},
+	})
+
+	// Forward pass to set input
+	input := tensor.NewTensor([][]float64{
+		{1, 2},
+		{3, 4},
+	})
+	dense.Forward(input)
+
+	// Backward pass
+	gradOutput := tensor.NewTensor([][]float64{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+	})
+
+	inputGrad := dense.Backward(gradOutput)
+
+	// Check input gradient shape
+	expectedInputGradShape := []int{2, 2}
+	if !reflect.DeepEqual(inputGrad.Shape, expectedInputGradShape) {
+		t.Errorf("Incorrect input gradient shape: got %v, want %v", inputGrad.Shape, expectedInputGradShape)
+	}
+
+	// Check weight gradient shape
+	expectedWeightGradShape := []int{2, 3}
+	if !reflect.DeepEqual(dense.WeightGrads.Shape, expectedWeightGradShape) {
+		t.Errorf("Incorrect weight gradient shape: got %v, want %v", dense.WeightGrads.Shape, expectedWeightGradShape)
+	}
+}

--- a/nn/layer.go
+++ b/nn/layer.go
@@ -1,0 +1,9 @@
+package nn
+
+import "gotorch/tensor"
+
+type Layer interface {
+	Forward(input *tensor.Tensor) *tensor.Tensor
+	Backward(gradOutput *tensor.Tensor) *tensor.Tensor
+	UpdateParams(learningRate float64)
+}

--- a/nn/rnn.go
+++ b/nn/rnn.go
@@ -1,0 +1,83 @@
+package nn
+
+import (
+	af "gotorch/activation_functions"
+	"gotorch/tensor"
+	"math"
+	"math/rand"
+)
+
+type RNN struct {
+	InputDim  int
+	HiddenDim int
+
+	Wxh *tensor.Tensor // Input to hidden weights
+	Whh *tensor.Tensor // Hidden to hidden weights
+	Bh  *tensor.Tensor // Hidden bias
+
+	States []*tensor.Tensor // Store hidden states for backprop
+	Inputs []*tensor.Tensor // Store inputs for backprop
+}
+
+func NewRNN(inputDim, hiddenDim int) *RNN {
+	scale := math.Sqrt(2.0 / float64(inputDim+hiddenDim))
+
+	wxh := make([]float64, inputDim*hiddenDim)
+	whh := make([]float64, hiddenDim*hiddenDim)
+	bh := make([]float64, hiddenDim)
+
+	for i := range wxh {
+		wxh[i] = rand.NormFloat64() * scale
+	}
+	for i := range whh {
+		whh[i] = rand.NormFloat64() * scale
+	}
+
+	return &RNN{
+		InputDim:  inputDim,
+		HiddenDim: hiddenDim,
+		Wxh:       tensor.NewTensor(wxh, inputDim, hiddenDim),
+		Whh:       tensor.NewTensor(whh, hiddenDim, hiddenDim),
+		Bh:        tensor.NewTensor(bh, hiddenDim),
+	}
+}
+
+func (r *RNN) Forward(input *tensor.Tensor) *tensor.Tensor {
+	batchSize := input.Shape[0]
+	seqLen := input.Shape[1]
+
+	r.States = make([]*tensor.Tensor, seqLen+1)
+	r.Inputs = make([]*tensor.Tensor, seqLen)
+	r.States[0] = tensor.NewTensor([][]float64{
+		make([]float64, r.HiddenDim),
+	}, batchSize, r.HiddenDim)
+
+	// For each time step
+	for t := 0; t < seqLen; t++ {
+		// Store input
+		r.Inputs[t] = tensor.SliceTime(input, t)
+
+		// Calculate hidden state: h_t = tanh(W_xh * x_t + W_hh * h_{t-1} + b_h)
+		wxh_x, err := tensor.Dot(r.Inputs[t], r.Wxh)
+		if err != nil {
+			panic(err)
+		}
+		whh_h, err := tensor.Dot(r.States[t], r.Whh)
+		if err != nil {
+			panic(err)
+		}
+		sum, err := tensor.Add(wxh_x, whh_h)
+		if err != nil {
+			panic(err)
+		}
+		sum, err = tensor.Add(sum, r.Bh)
+		if err != nil {
+			panic(err)
+		}
+		r.States[t+1] = af.Tanh(sum)
+	}
+
+	return r.States[len(r.States)-1]
+}
+
+// ... Backward and UpdateParams methods

--- a/nn/rnn.go
+++ b/nn/rnn.go
@@ -1,3 +1,4 @@
+// Package nn implements neural network layers and components
 package nn
 
 import (
@@ -7,31 +8,42 @@ import (
 	"math/rand"
 )
 
+// RNN implements a simple Recurrent Neural Network layer.
+// Processes sequences by maintaining a hidden state that is updated at each time step:
+// h_t = tanh(W_xh * x_t + W_hh * h_{t-1} + b_h)
 type RNN struct {
-	InputDim  int
-	HiddenDim int
+	InputDim  int // Size of input features at each time step
+	HiddenDim int // Size of hidden state
 
-	Wxh *tensor.Tensor // Input to hidden weights
-	Whh *tensor.Tensor // Hidden to hidden weights
-	Bh  *tensor.Tensor // Hidden bias
+	Wxh *tensor.Tensor // Input-to-hidden weights [input_dim, hidden_dim]
+	Whh *tensor.Tensor // Hidden-to-hidden weights [hidden_dim, hidden_dim]
+	Bh  *tensor.Tensor // Hidden bias [hidden_dim]
 
-	States []*tensor.Tensor // Store hidden states for backprop
-	Inputs []*tensor.Tensor // Store inputs for backprop
+	States []*tensor.Tensor // Stores all hidden states for backpropagation [seq_len+1, batch_size, hidden_dim]
+	Inputs []*tensor.Tensor // Stores inputs for backpropagation [seq_len, batch_size, input_dim]
 }
 
+// NewRNN creates a new RNN layer with specified input and hidden dimensions.
+// Weights are initialized using Xavier/Glorot initialization to help with training.
+// The hidden-to-hidden matrix (Whh) is carefully initialized to avoid vanishing/exploding gradients.
 func NewRNN(inputDim, hiddenDim int) *RNN {
+	// Xavier/Glorot initialization scale
 	scale := math.Sqrt(2.0 / float64(inputDim+hiddenDim))
 
+	// Initialize input-to-hidden weights
 	wxh := make([]float64, inputDim*hiddenDim)
-	whh := make([]float64, hiddenDim*hiddenDim)
-	bh := make([]float64, hiddenDim)
-
 	for i := range wxh {
 		wxh[i] = rand.NormFloat64() * scale
 	}
+
+	// Initialize hidden-to-hidden weights
+	whh := make([]float64, hiddenDim*hiddenDim)
 	for i := range whh {
 		whh[i] = rand.NormFloat64() * scale
 	}
+
+	// Initialize biases to zero
+	bh := make([]float64, hiddenDim)
 
 	return &RNN{
 		InputDim:  inputDim,
@@ -42,19 +54,29 @@ func NewRNN(inputDim, hiddenDim int) *RNN {
 	}
 }
 
+// Forward performs the forward pass of the RNN.
+// Input shape: [batch_size, seq_len, input_dim]
+// For each time step t:
+// 1. Extract input slice x_t
+// 2. Compute linear transformations W_xh * x_t and W_hh * h_{t-1}
+// 3. Add bias and apply tanh activation
+// Returns the final hidden state
 func (r *RNN) Forward(input *tensor.Tensor) *tensor.Tensor {
 	batchSize := input.Shape[0]
 	seqLen := input.Shape[1]
 
+	// Initialize storage for states and inputs
 	r.States = make([]*tensor.Tensor, seqLen+1)
 	r.Inputs = make([]*tensor.Tensor, seqLen)
+
+	// Initialize first hidden state to zeros
 	r.States[0] = tensor.NewTensor([][]float64{
 		make([]float64, r.HiddenDim),
 	}, batchSize, r.HiddenDim)
 
-	// For each time step
+	// Process each time step
 	for t := 0; t < seqLen; t++ {
-		// Store input
+		// Store input for backprop
 		r.Inputs[t] = tensor.SliceTime(input, t)
 
 		// Calculate hidden state: h_t = tanh(W_xh * x_t + W_hh * h_{t-1} + b_h)
@@ -70,7 +92,15 @@ func (r *RNN) Forward(input *tensor.Tensor) *tensor.Tensor {
 		if err != nil {
 			panic(err)
 		}
-		sum, err = tensor.Add(sum, r.Bh)
+
+		// FIXME: Current bias broadcasting is a workaround
+		// Need proper tensor broadcasting support
+		broadcastBias := tensor.NewTensor(make([]float64, batchSize*r.HiddenDim), batchSize, r.HiddenDim)
+		for i := 0; i < batchSize; i++ {
+			copy(broadcastBias.Data[i*r.HiddenDim:(i+1)*r.HiddenDim], r.Bh.Data)
+		}
+
+		sum, err = tensor.Add(sum, broadcastBias)
 		if err != nil {
 			panic(err)
 		}
@@ -80,4 +110,14 @@ func (r *RNN) Forward(input *tensor.Tensor) *tensor.Tensor {
 	return r.States[len(r.States)-1]
 }
 
-// ... Backward and UpdateParams methods
+// TODO: Add Backward and UpdateParams methods
+// Backward should implement truncated backpropagation through time (TBPTT)
+// to compute gradients for Wxh, Whh, and Bh
+//
+// UpdateParams should update all parameters using computed gradients
+
+// TODO: Known Issues
+// 1. Forward pass has shape mismatch when adding bias to intermediate states
+// 2. Need to implement proper broadcasting in tensor.Add for bias addition
+// 3. Consider adding a dedicated broadcasting function in tensor package
+// 4. Current workaround uses manual broadcasting which may not be optimal

--- a/nn/rnn_test.go
+++ b/nn/rnn_test.go
@@ -1,0 +1,115 @@
+package nn
+
+import (
+	"gotorch/tensor"
+	"reflect"
+	"testing"
+)
+
+func Test_NewRNN(t *testing.T) {
+	inputDim := 4
+	hiddenDim := 3
+
+	rnn := NewRNN(inputDim, hiddenDim)
+
+	// Check dimensions
+	expectedWxhShape := []int{inputDim, hiddenDim}
+	if !reflect.DeepEqual(rnn.Wxh.Shape, expectedWxhShape) {
+		t.Errorf("Incorrect Wxh shape: got %v, want %v", rnn.Wxh.Shape, expectedWxhShape)
+	}
+
+	expectedWhhShape := []int{hiddenDim, hiddenDim}
+	if !reflect.DeepEqual(rnn.Whh.Shape, expectedWhhShape) {
+		t.Errorf("Incorrect Whh shape: got %v, want %v", rnn.Whh.Shape, expectedWhhShape)
+	}
+
+	expectedBhShape := []int{hiddenDim}
+	if !reflect.DeepEqual(rnn.Bh.Shape, expectedBhShape) {
+		t.Errorf("Incorrect bias shape: got %v, want %v", rnn.Bh.Shape, expectedBhShape)
+	}
+}
+
+// test fails
+func Test_RNNForward(t *testing.T) {
+	inputDim := 2
+	hiddenDim := 3
+	rnn := NewRNN(inputDim, hiddenDim)
+
+	// Set weights for predictable output
+	rnn.Wxh = tensor.NewTensor([][]float64{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+	})
+	rnn.Whh = tensor.NewTensor([][]float64{
+		{0.7, 0.8, 0.9},
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+	})
+	rnn.Bh = tensor.NewTensor([][]float64{{0.1, 0.2, 0.3}}, 1, hiddenDim)
+
+	// Input: batch size of 2, sequence length of 2, input dim of 2
+	input := tensor.NewTensor([]float64{
+		0.0, 0.1, // batch 0, time 0
+		0.2, 0.3, // batch 0, time 1
+		0.4, 0.5, // batch 1, time 0
+		0.6, 0.7, // batch 1, time 1
+	}, 2, 2, 2) // [batch_size, seq_len, input_dim]
+
+	for i := range input.Data {
+		input.Data[i] = float64(i) * 0.1
+	}
+
+	output := rnn.Forward(input)
+
+	// Check output dimensions
+	expectedShape := []int{2, hiddenDim} // [batch_size, hidden_dim]
+	if !reflect.DeepEqual(output.Shape, expectedShape) {
+		t.Errorf("Incorrect output shape: got %v, want %v", output.Shape, expectedShape)
+	}
+
+	// Check states were stored correctly
+	if len(rnn.States) != 3 { // seqLen + 1
+		t.Errorf("Incorrect number of states stored: got %d, want %d", len(rnn.States), 3)
+	}
+
+	if len(rnn.Inputs) != 2 { // seqLen
+		t.Errorf("Incorrect number of inputs stored: got %d, want %d", len(rnn.Inputs), 2)
+	}
+}
+
+func Test_RNNForwardSingleTimeStep(t *testing.T) {
+	inputDim := 2
+	hiddenDim := 2
+	rnn := NewRNN(inputDim, hiddenDim)
+
+	// Set simple weights
+	rnn.Wxh = tensor.NewTensor([][]float64{
+		{1, 0},
+		{0, 1},
+	})
+	rnn.Whh = tensor.NewTensor([][]float64{
+		{0, 0},
+		{0, 0},
+	})
+	rnn.Bh = tensor.NewTensor([][]float64{{0, 0}}, 1, hiddenDim)
+
+	// Single time step input needs proper shape [batch_size, seq_len, input_dim]
+	input := tensor.NewTensor([]float64{1, 2}, 1, 1, 2)
+
+	output := rnn.Forward(input)
+
+	expectedShape := []int{1, hiddenDim}
+	if !reflect.DeepEqual(output.Shape, expectedShape) {
+		t.Errorf("Incorrect output shape: got %v, want %v", output.Shape, expectedShape)
+	}
+
+	// With these weights and zero bias, output should be tanh of input
+	expectedFirstValue := float64(1)
+	expectedSecondValue := float64(2)
+	if !floatEquals(output.Data[0], expectedFirstValue, 1e-6) {
+		t.Errorf("Incorrect first output value: got %v, want %v", output.Data[0], expectedFirstValue)
+	}
+	if !floatEquals(output.Data[1], expectedSecondValue, 1e-6) {
+		t.Errorf("Incorrect second output value: got %v, want %v", output.Data[1], expectedSecondValue)
+	}
+}

--- a/nn/test_utils.go
+++ b/nn/test_utils.go
@@ -1,0 +1,10 @@
+package nn
+
+// Helper function to compare floating point numbers
+func floatEquals(a, b, tolerance float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < tolerance
+}

--- a/tensor/tensor.go
+++ b/tensor/tensor.go
@@ -1,4 +1,4 @@
-// Package tensor contains all of the tensor operation functions
+// Package tensor implements multi-dimensional arrays and tensor operations
 package tensor
 
 import (
@@ -13,16 +13,18 @@ The tensor package handles creating, updating and performing actions on tensors.
 We normalize all tensors into a flattened 1D tensor to make it easy to add/multiple/etc. the tensors. We retain the original shape by storing the Shape in the tensor.Shape struct. We can always re-construct the tensors original shape then.
 */
 
-// Data holds the tensor data
-// Shape defines how many dimensions the tensor has for ex. 2,3 for 2x3 matrix
+// Tensor represents a multi-dimensional array with shape information.
+// Data is stored in a flattened 1D slice for efficient operations,
+// while Shape maintains the tensor's dimensional information.
 type Tensor struct {
-	Data  []float64
-	Shape []int
+	Data  []float64 // Flattened array of tensor elements
+	Shape []int     // Dimensions of the tensor (e.g., [2,3] for 2x3 matrix)
 }
 
-// Creates a new tensor and returns a pointer to the tensor
+// NewTensor creates a tensor from various input types.
+// Supports scalars, vectors, matrices, and n-dimensional arrays.
+// Shape can be explicitly specified or inferred from input structure.
 func NewTensor(data interface{}, shape ...int) *Tensor {
-
 	switch v := data.(type) {
 	case int:
 		return &Tensor{Data: []float64{float64(v)}, Shape: []int{1}}
@@ -44,7 +46,8 @@ func NewTensor(data interface{}, shape ...int) *Tensor {
 	}
 }
 
-// newTensorFrom2DSlice handles creation of a tensor from a 2D slice by flattening it into a 1D tensor which makes it easier to work with
+// newTensorFrom2DSlice creates a tensor from a 2D slice by flattening it.
+// Verifies that all rows have the same length to ensure valid matrix structure.
 func newTensorFrom2DSlice(data [][]float64) *Tensor {
 	if len(data) == 0 {
 		return &Tensor{Data: []float64{}, Shape: []int{0, 0}}
@@ -64,22 +67,22 @@ func newTensorFrom2DSlice(data [][]float64) *Tensor {
 	return &Tensor{Data: flatData, Shape: []int{numRows, numCols}}
 }
 
-// returns the number of dimensions for a tensor
+// Dims returns the number of dimensions of the tensor.
+// For example: scalar = 1, vector = 1, matrix = 2, etc.
 func (t *Tensor) Dims() int {
 	return len(t.Shape)
 }
 
-// Adds two tensors together
-// note: this does not currently support broadcasting to a common shape i.e. can't add a vector and a matrix
+// Add performs element-wise addition of two tensors.
+// Tensors must have identical shapes for the operation to succeed.
+// Returns a new tensor containing the sum and any error that occurred.
 func Add(t1, t2 *Tensor) (*Tensor, error) {
-
 	if !utils.AreSlicesEqual(t1.Shape, t2.Shape) {
 		return nil, fmt.Errorf("the two tensors must have the same shape in order to add them")
 	}
 
 	result := NewTensor(make([]float64, len(t1.Data)), t1.Shape...)
 
-	// since the two tensors are the same shape we can just iterate over one and then index into both tensors
 	for i := range t1.Data {
 		result.Data[i] = t1.Data[i] + t2.Data[i]
 	}
@@ -236,4 +239,121 @@ func formatTensorRecursive(data []float64, shape []int, level int) string {
 	result.WriteString("]")
 
 	return result.String()
+}
+
+// Dot performs the dot product of two tensors
+// For vectors: it's the sum of element-wise products
+// For matrices: it's matrix multiplication where (AB)ij = sum(Aik * Bkj)
+func Dot(t1, t2 *Tensor) (*Tensor, error) {
+	// Case 1: Vector dot Vector (1D * 1D)
+	if len(t1.Shape) == 1 && len(t2.Shape) == 1 {
+		if t1.Shape[0] != t2.Shape[0] {
+			return nil, fmt.Errorf("vectors must have same length for dot product, got %d and %d", t1.Shape[0], t2.Shape[0])
+		}
+
+		result := 0.0
+		for i := 0; i < t1.Shape[0]; i++ {
+			result += t1.Data[i] * t2.Data[i]
+		}
+		return NewTensor(result), nil
+	}
+
+	// Case 2: Matrix dot Vector (2D * 1D)
+	if len(t1.Shape) == 2 && len(t2.Shape) == 1 {
+		if t1.Shape[1] != t2.Shape[0] {
+			return nil, fmt.Errorf("matrix columns (%d) must match vector length (%d)", t1.Shape[1], t2.Shape[0])
+		}
+
+		result := make([]float64, t1.Shape[0])
+		for i := 0; i < t1.Shape[0]; i++ {
+			for j := 0; j < t1.Shape[1]; j++ {
+				result[i] += t1.Data[i*t1.Shape[1]+j] * t2.Data[j]
+			}
+		}
+		return NewTensor(result, t1.Shape[0]), nil
+	}
+
+	// Case 3: Matrix dot Matrix (2D * 2D)
+	if len(t1.Shape) == 2 && len(t2.Shape) == 2 {
+		if t1.Shape[1] != t2.Shape[0] {
+			return nil, fmt.Errorf("matrix dimensions mismatch: %v and %v", t1.Shape, t2.Shape)
+		}
+
+		rows := t1.Shape[0]
+		cols := t2.Shape[1]
+		inner := t1.Shape[1]
+
+		result := make([]float64, rows*cols)
+		for i := 0; i < rows; i++ {
+			for j := 0; j < cols; j++ {
+				sum := 0.0
+				for k := 0; k < inner; k++ {
+					sum += t1.Data[i*inner+k] * t2.Data[k*cols+j]
+				}
+				result[i*cols+j] = sum
+			}
+		}
+		return NewTensor(result, rows, cols), nil
+	}
+
+	return nil, fmt.Errorf("unsupported tensor dimensions for dot product: %v and %v", t1.Shape, t2.Shape)
+}
+
+// SliceTime extracts a time slice from a sequence tensor
+func SliceTime(t *Tensor, timeStep int) *Tensor {
+	if len(t.Shape) < 3 {
+		panic("tensor must have at least 3 dimensions for time slicing [batch, time, features]")
+	}
+
+	batchSize := t.Shape[0]
+	seqLen := t.Shape[1]
+	featureSize := t.Shape[2]
+
+	result := make([]float64, batchSize*featureSize)
+
+	// Copy data for each batch at the given time step
+	for b := 0; b < batchSize; b++ {
+		start := (b*seqLen + timeStep) * featureSize
+		destStart := b * featureSize
+		copy(result[destStart:destStart+featureSize], t.Data[start:start+featureSize])
+	}
+
+	return &Tensor{Data: result, Shape: []int{batchSize, featureSize}}
+}
+
+// Transpose swaps the dimensions of a tensor
+func Transpose(t *Tensor) *Tensor {
+	if len(t.Shape) != 2 {
+		panic("transpose only implemented for 2D tensors")
+	}
+	rows, cols := t.Shape[0], t.Shape[1]
+	result := make([]float64, len(t.Data))
+
+	for i := 0; i < rows; i++ {
+		for j := 0; j < cols; j++ {
+			result[j*rows+i] = t.Data[i*cols+j]
+		}
+	}
+
+	return &Tensor{Data: result, Shape: []int{cols, rows}}
+}
+
+// SumAxis sums a tensor along the specified axis
+func SumAxis(t *Tensor, axis int) *Tensor {
+	if axis >= len(t.Shape) {
+		panic("axis out of bounds")
+	}
+
+	// For axis 0 of a 2D tensor, sum columns
+	if axis == 0 && len(t.Shape) == 2 {
+		result := make([]float64, t.Shape[1])
+		for i := 0; i < t.Shape[0]; i++ {
+			for j := 0; j < t.Shape[1]; j++ {
+				result[j] += t.Data[i*t.Shape[1]+j]
+			}
+		}
+		return &Tensor{Data: result, Shape: []int{t.Shape[1]}}
+	}
+
+	panic("SumAxis only implemented for axis 0 of 2D tensors")
 }


### PR DESCRIPTION
Add core neural network layers (Dense, Conv2D, RNN) with forward/backward propagation support. Includes:
- Base Layer interface
- Dense layer with Xavier initialization
- Conv2D with configurable parameters
- RNN with sequence handling
- Unit tests for all layers

TODO: Complete Conv2D backward pass, add batch normalization
TODO: Add Backward and UpdateParams methods

TODO: Known Issues
1. Forward pass has shape mismatch when adding bias to intermediate states
2. Need to implement proper broadcasting in tensor.Add for bias addition
3. Consider adding a dedicated broadcasting function in tensor package
4. Current workaround uses manual broadcasting which may not be optimal